### PR TITLE
Added missing archs and Arch constant

### DIFF
--- a/pkgbuild.go
+++ b/pkgbuild.go
@@ -24,6 +24,8 @@ const (
 	ARMv6h
 	// ARMv7h architecture (archlinux-arm)
 	ARMv7h
+	// ARMv8 architecture (64bit) (archlinux-arm)
+	ARMv8
 	// MIPS64 architecture
 	MIPS64
 )
@@ -31,9 +33,9 @@ const (
 var archs = map[string]Arch{
 	"any":      Any,
 	"i686":     I686,
-	"x86_64":   X8664,
 	"x86":      I686,
-	"aarch64":  X8664,
+	"x86_64":   X8664,
+	"aarch64":  ARMv8,
 	"arm":      ARMv5,
 	"armv5":    ARMv5,
 	"armv6h":   ARMv6h,

--- a/pkgbuild.go
+++ b/pkgbuild.go
@@ -24,15 +24,21 @@ const (
 	ARMv6h
 	// ARMv7h architecture (archlinux-arm)
 	ARMv7h
+	// MIPS64 architecture
+	MIPS64
 )
 
 var archs = map[string]Arch{
-	"any":    Any,
-	"i686":   I686,
-	"x86_64": X8664,
-	"armv5":  ARMv5,
-	"armv6h": ARMv6h,
-	"armv7h": ARMv7h,
+	"any":      Any,
+	"i686":     I686,
+	"x86_64":   X8664,
+	"x86":      I686,
+	"aarch64":  X8664,
+	"arm":      ARMv5,
+	"armv5":    ARMv5,
+	"armv6h":   ARMv6h,
+	"armv7h":   ARMv7h,
+	"mips64el": MIPS64,
 }
 
 // Dependency describes a dependency with min and max version, if any.


### PR DESCRIPTION
Unfortunately there are some very mean packages on the AUR that don't play well with gopkgbuild. https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=package-query being one of them, going even to the effort of adding MIPS64 as a compatible architecture.

This is an ugly patch for the problem but it is the one that requires minimal effort.