### PR TITLE
Parse rel as a Version string

### DIFF
--- a/pkgbuild.go
+++ b/pkgbuild.go
@@ -64,7 +64,7 @@ type Dependency struct {
 type PKGBUILD struct {
 	Pkgnames     []string
 	Pkgver       Version // required
-	Pkgrel       int     // required
+	Pkgrel       Version // required
 	Pkgdir       string
 	Epoch        int
 	Pkgbase      string
@@ -132,10 +132,10 @@ func (p *PKGBUILD) Older(p2 *PKGBUILD) bool {
 // Version returns the full version of the PKGBUILD (including epoch and rel)
 func (p *PKGBUILD) Version() string {
 	if p.Epoch > 0 {
-		return fmt.Sprintf("%d:%s-%d", p.Epoch, p.Pkgver, p.Pkgrel)
+		return fmt.Sprintf("%d:%s-%s", p.Epoch, p.Pkgver, p.Pkgrel)
 	}
 
-	return fmt.Sprintf("%s-%d", p.Pkgver, p.Pkgrel)
+	return fmt.Sprintf("%s-%s", p.Pkgver, p.Pkgrel)
 }
 
 // CompleteVersion returns a Complete version struct including version, rel and
@@ -144,7 +144,7 @@ func (p *PKGBUILD) CompleteVersion() CompleteVersion {
 	return CompleteVersion{
 		Version: p.Pkgver,
 		Epoch:   uint8(p.Epoch),
-		Pkgrel:  uint8(p.Pkgrel),
+		Pkgrel:  p.Pkgrel,
 	}
 }
 
@@ -257,11 +257,11 @@ Loop:
 			pkgbuild.Pkgver = version
 		case itemPkgrel:
 			next = lexer.nextItem()
-			rel, err := strconv.ParseInt(next.val, 10, 0)
+			rel, err := parseVersion(next.val)
 			if err != nil {
 				return nil, err
 			}
-			pkgbuild.Pkgrel = int(rel)
+			pkgbuild.Pkgrel = rel
 		case itemPkgdir:
 			next = lexer.nextItem()
 			pkgbuild.Pkgdir = next.val

--- a/pkgbuild_test.go
+++ b/pkgbuild_test.go
@@ -31,9 +31,9 @@ func TestVersionParsing(t *testing.T) {
 // Test complete-version parsing
 func TestCompleteVersionParsing(t *testing.T) {
 	versions := map[string]*CompleteVersion{
-		"1:1.0beta": &CompleteVersion{Version("1.0beta"), 1, 0},
-		"1.0":       &CompleteVersion{Version("1.0"), 0, 0},
-		"2.3-2":     &CompleteVersion{Version("2.3"), 0, 2},
+		"1:1.0beta": &CompleteVersion{Version("1.0beta"), 1, ""},
+		"1.0":       &CompleteVersion{Version("1.0"), 0, ""},
+		"2.3-2":     &CompleteVersion{Version("2.3"), 0, "2"},
 		"1::":       nil,
 		"4.3--1":    nil,
 		"4.1-a":     nil,
@@ -60,22 +60,22 @@ func TestNewer(t *testing.T) {
 	a := &PKGBUILD{
 		Epoch:  0,
 		Pkgver: Version("1.0"),
-		Pkgrel: 1,
+		Pkgrel: "1",
 	}
 	b := &PKGBUILD{
 		Epoch:  0,
 		Pkgver: Version("2.0"),
-		Pkgrel: 1,
+		Pkgrel: "1",
 	}
 	c := &PKGBUILD{
 		Epoch:  1,
 		Pkgver: Version("1.0"),
-		Pkgrel: 1,
+		Pkgrel: "1",
 	}
 	d := &PKGBUILD{
 		Epoch:  0,
 		Pkgver: Version("1.0"),
-		Pkgrel: 2,
+		Pkgrel: "2",
 	}
 
 	if a.Newer(b) {
@@ -100,22 +100,22 @@ func TestOlder(t *testing.T) {
 	a := &PKGBUILD{
 		Epoch:  0,
 		Pkgver: Version("1.0"),
-		Pkgrel: 1,
+		Pkgrel: "1",
 	}
 	b := &PKGBUILD{
 		Epoch:  0,
 		Pkgver: Version("2.0"),
-		Pkgrel: 1,
+		Pkgrel: "1",
 	}
 	c := &PKGBUILD{
 		Epoch:  1,
 		Pkgver: Version("1.0"),
-		Pkgrel: 1,
+		Pkgrel: "1",
 	}
 	d := &PKGBUILD{
 		Epoch:  0,
 		Pkgver: Version("1.0"),
-		Pkgrel: 2,
+		Pkgrel: "2",
 	}
 
 	if !a.Older(b) {
@@ -140,7 +140,7 @@ func TestVersionMethod(t *testing.T) {
 	a := &PKGBUILD{
 		Epoch:  0,
 		Pkgver: Version("1.0"),
-		Pkgrel: 1,
+		Pkgrel: "1",
 	}
 
 	version := "1.0-1"
@@ -152,7 +152,7 @@ func TestVersionMethod(t *testing.T) {
 	b := &PKGBUILD{
 		Epoch:  4,
 		Pkgver: Version("1.0"),
-		Pkgrel: 1,
+		Pkgrel: "1",
 	}
 
 	version = "4:1.0-1"

--- a/version.go
+++ b/version.go
@@ -12,7 +12,7 @@ type Version string
 type CompleteVersion struct {
 	Version Version
 	Epoch   uint8
-	Pkgrel  uint8
+	Pkgrel  Version
 }
 
 func (c *CompleteVersion) String() string {
@@ -24,7 +24,7 @@ func (c *CompleteVersion) String() string {
 func NewCompleteVersion(s string) (*CompleteVersion, error) {
 	var err error
 	epoch := 0
-	rel := 0
+	rel := Version("")
 
 	// handle possible epoch
 	versions := strings.Split(s, ":")
@@ -46,10 +46,7 @@ func NewCompleteVersion(s string) (*CompleteVersion, error) {
 	}
 
 	if len(versions) > 1 {
-		rel, err = strconv.Atoi(versions[1])
-		if err != nil {
-			return nil, err
-		}
+		rel = Version(versions[1])
 	}
 
 	// finally check that the actual version is valid
@@ -57,7 +54,7 @@ func NewCompleteVersion(s string) (*CompleteVersion, error) {
 		return &CompleteVersion{
 			Version: Version(versions[0]),
 			Epoch:   uint8(epoch),
-			Pkgrel:  uint8(rel),
+			Pkgrel:  rel,
 		}, nil
 	}
 
@@ -115,11 +112,11 @@ func (a *CompleteVersion) cmp(b *CompleteVersion) int8 {
 		return -1
 	}
 
-	if a.Pkgrel > b.Pkgrel {
+	if a.Pkgrel.bigger(b.Pkgrel) {
 		return 1
 	}
 
-	if a.Pkgrel < b.Pkgrel {
+	if b.Pkgrel.bigger(a.Pkgrel) {
 		return -1
 	}
 

--- a/version_test.go
+++ b/version_test.go
@@ -86,12 +86,13 @@ func TestCompleteVersionComparison(t *testing.T) {
 	a := &CompleteVersion{
 		Version: "2",
 		Epoch:   1,
-		Pkgrel:  2,
+		Pkgrel:  Version("2"),
 	}
 
 	older := []string{
 		"0-3-4",
 		"1-2-1",
+		"1-2-1.5",
 		"1-1-1",
 	}
 
@@ -105,6 +106,7 @@ func TestCompleteVersionComparison(t *testing.T) {
 		"2-1-1",
 		"1-3-1",
 		"1-2-3",
+		"1-2-2.1",
 	}
 
 	for _, n := range newer {


### PR DESCRIPTION
Parses the rel as a version to handle the cases where one version of a package has a rel defined as `Major.Minor` and another has is defined just as `Major`.

Previously `Major` was always assumed.

Fix #2