### PR TITLE
Allow '~' in pkgver

### DIFF
--- a/pkgbuild.go
+++ b/pkgbuild.go
@@ -526,5 +526,5 @@ func isValidPkgnameChar(c uint8) bool {
 
 // check if c is a valid pkgver char
 func isValidPkgverChar(c uint8) bool {
-	return isAlphaNumeric(c) || c == '_' || c == '+' || c == '.'
+	return isAlphaNumeric(c) || c == '_' || c == '+' || c == '.' || c == '~'
 }

--- a/pkgbuild_test.go
+++ b/pkgbuild_test.go
@@ -9,11 +9,16 @@ func TestVersionParsing(t *testing.T) {
 		"1.0.0.0.2": true,
 		"a.3_4":     true,
 		"A.2":       true,
+		"a~b~c":     true,
 		"_1.2":      false,
 		".2":        false,
 		"a.2Ø":      false,
 		"1.?":       false,
 		"1.-":       false,
+		"1 2":       false,
+		"1\t2":      false,
+		"1\n2":      false,
+		"1\r2":      false,
 	}
 
 	for version, valid := range versions {


### PR DESCRIPTION
The validity check on pkgver is way too strict. makepkg itself states:
`pkgver is not allowed to contain colons, hyphens or whitespace.`
makepkg itself also seems a little broken allowing pkgvers with white space and also allowing `:` and `-`  as long as they come after whitespace. makepkg also seems to allow all unicode characters.

Most of the time this strictness does not cause a problem, although some packages on the AUR and the main repos contain a `~` in their version causing an error to be thrown.

Currently all I have done is added `~` as an allowed character. Although I think check checking method should be changed from a white-list to a black-list where we accept all characters apart from `:`, `-`, whitespace and unicode.