### PR TITLE
Stop execess emits of itemEndSplit

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -202,9 +202,12 @@ func lexEnv(l *lexer) stateFn {
 			return lexVariable
 		case r == '\n':
 			buffer := l.input[l.start:l.pos]
-			if buffer == "\n" || buffer == "\n\n" {
+			if buffer == "\n" {
+				if l.peek() == '\n' {
+					l.next()
+					l.emit(itemEndSplit)
+				}
 				l.ignore()
-				l.emit(itemEndSplit)
 			}
 		case r == '\t':
 			l.ignore()


### PR DESCRIPTION
Just noticed after the last pr it now emits itemEndSplit after every \n. This version looks good to me although you might want to take a proper look at it. I would suggest maybe extending the tests to test for specific output instead of just seeing if the parse passed or failed. Sorry for not catching this before the first pr.