### PR TITLE
Expand the Dependency type

### DIFF
--- a/pkgbuild.go
+++ b/pkgbuild.go
@@ -486,7 +486,7 @@ func parseDependency(dep string, deps []*Dependency) ([]*Dependency, error) {
 	}
 
 	switch eq.String() {
-	case "==":
+	case "=":
 		dependency.MinVer = version
 		dependency.MaxVer = version
 	case "<=":

--- a/pkgbuild.go
+++ b/pkgbuild.go
@@ -91,6 +91,34 @@ func (a *Dependency) Restrict(b *Dependency) *Dependency {
 	return newDep
 }
 
+func (dep *Dependency) String() string {
+	str := ""
+	greaterThan := ">"
+	lessThan := "<"
+
+	if !dep.sgt {
+		greaterThan = ">="
+	}
+
+	if !dep.slt {
+		lessThan = "<="
+	}
+
+	if dep.MinVer != nil {
+		str += dep.Name + greaterThan + dep.MinVer.String()
+
+		if dep.MaxVer != nil {
+			str += " "
+		}
+	}
+
+	if dep.MaxVer != nil {
+		str += dep.Name + lessThan + dep.MaxVer.String()
+	}
+
+	return str
+}
+
 // PKGBUILD is a struct describing a parsed PKGBUILD file.
 // Required fields are:
 //	pkgname

--- a/pkgbuild_test.go
+++ b/pkgbuild_test.go
@@ -214,7 +214,7 @@ func TestParseDependency(t *testing.T) {
 		t.Errorf("could not parse dependency %s: %s", "bla", err.Error())
 	}
 
-	_, err = parseDependency("linux-mainline-headers==4.6rc1", deps)
+	_, err = parseDependency("linux-mainline-headers=4.6rc1", deps)
 	if err != nil {
 		t.Errorf("could not parse dependency %s: %s", "bla", err.Error())
 	}

--- a/version.go
+++ b/version.go
@@ -104,6 +104,41 @@ func (a *CompleteVersion) Equal(v string) bool {
 	return a.cmp(b) == 0
 }
 
+// Satisfies tests whether or not version fits inside the bounds specified by
+// dep
+func (version *CompleteVersion) Satisfies(dep *Dependency) bool {
+	var cmpMax int8
+	var cmpMin int8
+
+	if dep.MaxVer != nil {
+		cmpMax = version.cmp(dep.MaxVer)
+		if cmpMax == 1 {
+			return false
+		}
+
+		if cmpMax == 0 && dep.slt {
+			return false
+		}
+	}
+
+	if dep.MinVer != nil {
+		if dep.MaxVer == dep.MinVer {
+			cmpMin = cmpMax
+		} else {
+			cmpMin = version.cmp(dep.MinVer)
+		}
+		if cmpMin == -1 {
+			return false
+		}
+
+		if cmpMin == 0 && dep.sgt {
+			return false
+		}
+	}
+
+	return true
+}
+
 // Compare a to b:
 // return 1: a is newer than b
 //        0: a and b are the same version

--- a/version.go
+++ b/version.go
@@ -17,11 +17,19 @@ type CompleteVersion struct {
 }
 
 func (c *CompleteVersion) String() string {
+	str := ""
+
 	if c.Epoch > 0 {
-		return fmt.Sprintf("%d:%s-%s", c.Epoch, c.Version, c.Pkgrel)
+		str = fmt.Sprintf("%d:", c.Epoch)
 	}
 
-	return fmt.Sprintf("%s-%s", c.Version, c.Pkgrel)
+	str = fmt.Sprintf("%s%s", str, c.Version)
+
+	if c.Pkgrel != "" {
+		str = fmt.Sprintf("%s-%s", str, c.Pkgrel)
+	}
+
+	return str
 }
 
 // NewCompleteVersion creates a CompleteVersion including basic version, epoch
@@ -115,6 +123,10 @@ func (a *CompleteVersion) cmp(b *CompleteVersion) int8 {
 
 	if b.Version.bigger(a.Version) {
 		return -1
+	}
+
+	if a.Pkgrel == "" || b.Pkgrel == "" {
+		return 0
 	}
 
 	if a.Pkgrel.bigger(b.Pkgrel) {

--- a/version_test.go
+++ b/version_test.go
@@ -120,6 +120,21 @@ func TestCompleteVersionComparison(t *testing.T) {
 			t.Errorf("%s should be newer than %s", n, a.String())
 		}
 	}
+
+	equal := []string{
+		"1:2-2",
+		"1:2",
+	}
+
+	for _, n := range equal {
+		if _, err := NewCompleteVersion(n); err != nil {
+			t.Errorf("%s fails to parse %v", n, err)
+		}
+		if a.Newer(n) || a.Older(n) || !a.Equal(n) {
+			t.Errorf("%s should be equal to %s", n, a.String())
+		}
+	}
+
 }
 
 func TestCompleteVersionString(t *testing.T) {

--- a/version_test.go
+++ b/version_test.go
@@ -145,6 +145,59 @@ func TestCompleteVersionString(t *testing.T) {
 	}
 }
 
+func TestSatisfies(t *testing.T) {
+	deps, _ := ParseDeps([]string{
+		"a>1", "a<2",
+		"b>=1", "b<=2",
+		"c>=1:1", "c<=1:2",
+		"d=1.2.3",
+		"e=1.2.3-1",
+	})
+
+	versionPass := [][]string{
+		{"1.1", "1.9", "1.99", "1.001", "0:1.1"},
+		{"1.1", "1.9", "1.99", "1.001", "1", "2"},
+		{"1:1.1", "1:1.9", "1:1.99", "1:1.001", "1:1", "1:2"},
+		{"1.2.3", "1.2.3-1", "1.2.3-999", "0:1.2.3", "0:1.2.3-1", "0:1.2.3-999"},
+		{"1.2.3-1", "0:1.2.3-1"},
+	}
+
+	versionFail := [][]string{
+		{"0", "0.99", "2.001", "2"},
+		{"0", "0.99", "2.001"},
+		{"0:1.1", "2:1.9", "0:1.99", "2:1.001", "0:1", "2:2", "0:1.0", "2:2.0"},
+		{"1:1.2.3", "1.2.3.0", "1.2.3.1"},
+		{"1:1.2.3-1", "0:1.2.3-2", "1.2.3-3", "1.2.3-4"},
+	}
+
+	for i, dep := range deps {
+		versions := versionPass[i]
+		for _, versionStr := range versions {
+			version, err := NewCompleteVersion(versionStr)
+			if err != nil {
+				t.Errorf("%s fails to parse %v", versionStr, err)
+			}
+			if !version.Satisfies(dep) {
+				t.Errorf("%s should satisfy %+v", version, dep)
+			}
+		}
+	}
+
+	for i, dep := range deps {
+		versions := versionFail[i]
+		for _, versionStr := range versions {
+			version, err := NewCompleteVersion(versionStr)
+			if err != nil {
+				t.Errorf("%s fails to parse %v", versionStr, err)
+			}
+			if version.Satisfies(dep) {
+				t.Errorf("%s should not satisfy %+v", version, dep)
+			}
+		}
+	}
+
+}
+
 // Benchmark rpmvercmp
 func BenchmarkVersionCompare(b *testing.B) {
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
I've been working on dependency checking, specifically the versioned kind `foo>1`. 

gopkgbuild had the foundations there with the Dependency type but you couldn't really do much with it. For example, slt and sgt are both private so it was impossible to check if a version fit inside a dependency because there was no way to access it.

Also while managing multiple packages with their own dependencies it would be nice to merge their needs together. For example `a` depends on `foo>2` `foo<10` and `b` depends on `foo>1` `foo<3` for easier checking they could both be merged into a single Dependency `foo>2` `foo<3`.

I wrote some tests which all pass and also seem to be working fine in my own code that uses gopkgbuild.