### PR TITLE
Allow lowercase letters in pkgname

### DIFF
--- a/pkgbuild.go
+++ b/pkgbuild.go
@@ -616,7 +616,7 @@ func isLowerAlpha(c rune) bool {
 
 // check if c is a valid pkgname char
 func isValidPkgnameChar(c rune) bool {
-	return isLowerAlpha(c) || isDigit(c) || c == '@' || c == '.' || c == '_' || c == '+' || c == '-'
+	return isAlphaNumeric(c) || c == '@' || c == '.' || c == '_' || c == '+' || c == '-'
 }
 
 // check if c is a valid pkgver char


### PR DESCRIPTION
Although Arch has its own packaging guidelines such as package names
being lower case only. This is not a rule set by makepkg itself which is
what I believe we should be following.

Having too restrictive checks have caused problems again and again and
each restriction is slowly being lifted. I mentioned this in #11.

The point of this patch though is not just because we should allow it.
But because it causes real problems with packages such as xorg-server,
which has uppercase provides.