### PR TITLE
Compare CompleteVersion with a CompleteVersion

### DIFF
--- a/version.go
+++ b/version.go
@@ -74,33 +74,18 @@ func NewCompleteVersion(s string) (*CompleteVersion, error) {
 	return nil, fmt.Errorf("invalid version format: %s", s)
 }
 
-// Older returns true if a is older than the argument version string
-func (a *CompleteVersion) Older(v string) bool {
-	b, err := NewCompleteVersion(v)
-	if err != nil {
-		return false
-	}
-
+// Older returns true if a is older than the argument version
+func (a *CompleteVersion) Older(b *CompleteVersion) bool {
 	return a.cmp(b) == -1
 }
 
-// Newer returns true if a is newer than the argument version string
-func (a *CompleteVersion) Newer(v string) bool {
-	b, err := NewCompleteVersion(v)
-	if err != nil {
-		return false
-	}
-
+// Newer returns true if a is newer than the argument version
+func (a *CompleteVersion) Newer(b *CompleteVersion) bool {
 	return a.cmp(b) == 1
 }
 
-// Equal returns true if a is equal to the argument version string
-func (a *CompleteVersion) Equal(v string) bool {
-	b, err := NewCompleteVersion(v)
-	if err != nil {
-		return false
-	}
-
+// Equal returns true if a is equal to the argument version
+func (a *CompleteVersion) Equal(b *CompleteVersion) bool {
 	return a.cmp(b) == 0
 }
 

--- a/version_test.go
+++ b/version_test.go
@@ -97,10 +97,9 @@ func TestCompleteVersionComparison(t *testing.T) {
 	}
 
 	for _, o := range older {
-		if _, err := NewCompleteVersion(o); err != nil {
+		if b, err := NewCompleteVersion(o); err != nil {
 			t.Errorf("%s fails to parse %v", o, err)
-		}
-		if a.Older(o) || !a.Newer(o) {
+		} else if a.Older(b) || !a.Newer(b) {
 			t.Errorf("%s should be older than %s", o, a.String())
 		}
 	}
@@ -113,10 +112,9 @@ func TestCompleteVersionComparison(t *testing.T) {
 	}
 
 	for _, n := range newer {
-		if _, err := NewCompleteVersion(n); err != nil {
+		if b, err := NewCompleteVersion(n); err != nil {
 			t.Errorf("%s fails to parse %v", n, err)
-		}
-		if a.Newer(n) || !a.Older(n) {
+		} else if a.Newer(b) || !a.Older(b) {
 			t.Errorf("%s should be newer than %s", n, a.String())
 		}
 	}
@@ -127,10 +125,9 @@ func TestCompleteVersionComparison(t *testing.T) {
 	}
 
 	for _, n := range equal {
-		if _, err := NewCompleteVersion(n); err != nil {
+		if b, err := NewCompleteVersion(n); err != nil {
 			t.Errorf("%s fails to parse %v", n, err)
-		}
-		if a.Newer(n) || a.Older(n) || !a.Equal(n) {
+		} else if a.Newer(b) || a.Older(b) || !a.Equal(b) {
 			t.Errorf("%s should be equal to %s", n, a.String())
 		}
 	}


### PR DESCRIPTION
BREAKING CHANGE: Changes the API of CompleteVersion.Older/Newer/Equal
from accepting a `string` to `CompleteVersion` as argument.

Obsoletes #21.