### PR TITLE
Make lex.go skip spaces

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -211,6 +211,8 @@ func lexEnv(l *lexer) stateFn {
 			}
 		case r == '\t':
 			l.ignore()
+		case r == ' ':
+			l.ignore()
 		case r == '#':
 			return lexComment
 		default:

--- a/pkgbuild_test.go
+++ b/pkgbuild_test.go
@@ -182,6 +182,7 @@ func TestRandomCoreSRCINFOs(t *testing.T) {
 		"biicode",
 		"teamviewer",
 		"shaman-git",
+		"bash-snippets",
 	}
 
 	for _, srcinfo := range srcinfos {

--- a/test_pkgbuilds/PKGBUILD_bash-snippets
+++ b/test_pkgbuilds/PKGBUILD_bash-snippets
@@ -1,0 +1,18 @@
+# Maintainer: Alex Epstein <epsteina@wit.edu>
+
+pkgname=Bash-Snippets
+pkgver=1.18.0
+pkgrel=2
+pkgdesc="A collection of small bash scripts for heavy terminal users"
+arch=('any')
+url="https://github.com/alexanderepstein/Bash-Snippets"
+license=("MIT")
+source=("https://github.com/alexanderepstein/Bash-Snippets/archive/v$pkgver.tar.gz")
+depends=("bash" "curl" "openssl" "git" "bc")
+sha256sums=("61602551a999448e9142489ad62d1e5da72a3b1354e010f1ee7135e4524d2eae")
+
+package() {
+    tar -xf v$pkgver.tar.gz
+    cd Bash-Snippets-$pkgver
+    ./install.sh --prefix=/usr all
+}

--- a/test_pkgbuilds/SRCINFO_bash-snippets
+++ b/test_pkgbuilds/SRCINFO_bash-snippets
@@ -1,0 +1,16 @@
+pkgbase = bash-snippets
+	pkgdesc = A collection of small bash scripts for heavy terminal users
+	pkgver = 1.18.0
+	pkgrel = 2
+	url = https://github.com/alexanderepstein/Bash-Snippets
+	arch = any
+	license = MIT
+	depends = bash
+	depends = curl
+  	depends = openssl
+    depends = git
+	depends = bc
+	source = https://github.com/alexanderepstein/Bash-Snippets/archive/v1.18.0.tar.gz
+	sha256sums = 61602551a999448e9142489ad62d1e5da72a3b1354e010f1ee7135e4524d2eae
+
+pkgname = bash-snippets


### PR DESCRIPTION
This pull request should address issue #20 (if I understood it correctly)
and make _gopkgbuild_ skip spaces used for indentation in _SRCINFO_'s.